### PR TITLE
31 fetch photos for tiles

### DIFF
--- a/packages/frontend/src/components/Game/GameBoard/TileGrid/index.jsx
+++ b/packages/frontend/src/components/Game/GameBoard/TileGrid/index.jsx
@@ -1,21 +1,13 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import Tile from '../Tile';
-import { addTiles, flipTile } from 'contexts/game/actions';
+import { flipTile } from 'contexts/game/actions';
 import useGameContext from 'hooks/useGameContext';
 import './style.scss';
 
-const TileGrid = ({ photos }) => {
-  const { dispatch, state } = useGameContext();
+const TileGrid = ({ tiles }) => {
+  const { dispatch } = useGameContext();
 
-  useEffect(() => {
-    if (photos) {
-      console.log('There are photos');
-      dispatch(addTiles(photos));
-    }
-  }, [photos]);
-
-  const tiles = state.tiles;
   const onFlipTile = (tile) => {
     dispatch(flipTile(tile));
   };
@@ -44,8 +36,7 @@ const TileGrid = ({ photos }) => {
 };
 TileGrid.propTypes = {
   toggleUp: PropTypes.func,
-  // tiles: PropTypes.arrayOf(PropTypes.object),
-  photos: PropTypes.arrayOf(PropTypes.object),
+  tiles: PropTypes.arrayOf(PropTypes.object),
 };
 
 export default TileGrid;

--- a/packages/frontend/src/components/Game/GameBoard/TileGrid/index.test.jsx
+++ b/packages/frontend/src/components/Game/GameBoard/TileGrid/index.test.jsx
@@ -5,11 +5,9 @@ import { mockPhotos } from '__mocks__/api/mockPhotos';
 
 describe('TileGrid component', () => {
   it('renders all tiles', () => {
-    //TODO: adjust this test after the providers change ticket
+    const tiles = createTilesFromPhotos(mockPhotos, true)
     
-    // const tiles = createTilesFromPhotos(mockPhotos, true)
-    const photos = mockPhotos
-    const { screen } = setupTests(TileGrid, { props: { photos } });
+    const { screen } = setupTests(TileGrid, { props: { tiles } });
 
     const allTiles = screen.getAllByTestId(/tile/);
 

--- a/packages/frontend/src/components/Game/index.jsx
+++ b/packages/frontend/src/components/Game/index.jsx
@@ -12,7 +12,7 @@ const Game = () => {
     state: { error, status, photos },
   } = usePhotosContext();
   const {
-    state: { players, currentPlayer },
+    state: { players, currentPlayer, tiles },
   } = useGameContext();
 
   const isLoading = ['IDLE', 'PENDING'].includes(status);
@@ -26,7 +26,7 @@ const Game = () => {
       ) : (
         <>
           <ScoreBoard players={players} currentPlayer={currentPlayer} />
-          <TileGrid photos={photos} />
+          <TileGrid tiles={tiles} />
         </>
       )}
     </section>

--- a/packages/frontend/src/components/providers/game/index.jsx
+++ b/packages/frontend/src/components/providers/game/index.jsx
@@ -1,19 +1,24 @@
-import React, { useReducer } from 'react';
+import React, { useReducer, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { GameContext } from 'contexts/game';
-// import { addTiles } from 'contexts/game/actions';
+import { addTiles } from 'contexts/game/actions';
 import { baseState } from 'contexts';
 import { gameReducer } from 'contexts/game/reducer';
+import usePhotosContext from 'hooks/usePhotosContext';
 
 const GameProvider = ({ children, providedState = null } = {}) => {
   const initialState = providedState || baseState.game;
   const [state, dispatch] = useReducer(gameReducer, initialState);
 
-  // TODO: switch to calling add tiles here instead of in TileGrid once the
-  // photos provider is switched to wrap game provider
-  // useEffect(() => {
-  //   dispatch(addTiles(mockPhotos));
-  // }, []);
+  const {
+    state: { photos },
+  } = usePhotosContext();
+
+  useEffect(() => {
+    if (photos) {
+      dispatch(addTiles(photos));
+    }
+  }, [photos]);
 
   return (
     <GameContext.Provider value={{ state, dispatch }}>

--- a/packages/frontend/src/helpers/tests.jsx
+++ b/packages/frontend/src/helpers/tests.jsx
@@ -20,11 +20,11 @@ const setupTests = (
   render(
     <BrowserRouter>
       <FormProvider providedState={{ ...state.form }}>
-        <GameProvider providedState={{ ...state.game }}>
-          <PhotosProvider providedState={{ ...state.photos }}>
+        <PhotosProvider providedState={{ ...state.photos }}>
+          <GameProvider providedState={{ ...state.game }}>
             <Component {...props} />
-          </PhotosProvider>
-        </GameProvider>
+          </GameProvider>
+        </PhotosProvider>
       </FormProvider>
     </BrowserRouter>
   );

--- a/packages/frontend/src/index.js
+++ b/packages/frontend/src/index.js
@@ -14,11 +14,11 @@ root.render(
   <React.StrictMode>
     <BrowserRouter>
       <FormProvider>
-        <GameProvider>
-          <PhotosProvider>
+        <PhotosProvider>
+          <GameProvider>
             <App />
-          </PhotosProvider>
-        </GameProvider>
+          </GameProvider>
+        </PhotosProvider>
       </FormProvider>
     </BrowserRouter>
   </React.StrictMode>


### PR DESCRIPTION
﻿## Description of changes 

Game Provider is now a child of photo provider in app routing. The addTiles action is now called in the game provider and the TileGrid component receives tiles as a prop instead of photos.  The same change in order of the providers was made in the tests helper. 

The only thing that needs to be done is to fix the test for useGameContext. 

## Test steps
