### PR TITLE
5 tilegrid component removed matched tiles

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -52,6 +52,7 @@
     "@babel/preset-react": "^7.22.15",
     "dotenv": "^16.3.1",
     "eslint-plugin-prettier": "^5.0.0",
-    "msw": "^1.3.0"
+    "msw": "^1.3.0",
+    "testing-library-selector": "^0.3.1"
   }
 }

--- a/packages/frontend/src/components/Game/GameBoard/Tile/index.jsx
+++ b/packages/frontend/src/components/Game/GameBoard/Tile/index.jsx
@@ -8,8 +8,8 @@ const Tile = ({ tile, onFlip }) => {
   };
 
   const tileClasses = [
-    tile.faceUp ? 'faceUp' : 'faceDown',
-    tile.isMatched ? 'matched' : 'tile border border-primary',
+    tile.faceUp ? 'faceUp' : 'faceDown tile border border-primary',
+    tile.isMatched ? 'matched' : null,
   ].join(' ');
 
   return (

--- a/packages/frontend/src/components/Game/GameBoard/Tile/index.jsx
+++ b/packages/frontend/src/components/Game/GameBoard/Tile/index.jsx
@@ -8,8 +8,8 @@ const Tile = ({ tile, onFlip }) => {
   };
 
   const tileClasses = [
-    'tile border border-primary',
     tile.faceUp ? 'faceUp' : 'faceDown',
+    tile.isMatched ? 'matched' : 'tile border border-primary',
   ].join(' ');
 
   return (

--- a/packages/frontend/src/components/Game/GameBoard/Tile/index.test.jsx
+++ b/packages/frontend/src/components/Game/GameBoard/Tile/index.test.jsx
@@ -46,4 +46,13 @@ describe('Tile component', () => {
 
     expect(onFlip).toHaveBeenCalledTimes(1);
   });
+
+  it('has the class matched when isMatched is true', () => {
+    const tile = createTilesFromPhotos(mockPhotos)[0];
+    const props = { tile: {...tile, isMatched: true}};
+
+    const { screen } = setupTests(Tile, { props });
+
+    expect(screen.getByTestId(`tile-${tile.id}`)).toHaveClass('matched');
+  })
 });

--- a/packages/frontend/src/components/Game/GameBoard/Tile/style.scss
+++ b/packages/frontend/src/components/Game/GameBoard/Tile/style.scss
@@ -14,7 +14,5 @@
 }
 
 .matched {
-  img {
     display: none;
-  }
 }

--- a/packages/frontend/src/components/Game/GameBoard/Tile/style.scss
+++ b/packages/frontend/src/components/Game/GameBoard/Tile/style.scss
@@ -12,3 +12,9 @@
     width: 100%;
   }
 }
+
+.matched {
+  img {
+    display: none;
+  }
+}

--- a/packages/frontend/src/components/Game/GameBoard/TileGrid/index.jsx
+++ b/packages/frontend/src/components/Game/GameBoard/TileGrid/index.jsx
@@ -26,7 +26,7 @@ const TileGrid = ({ tiles }) => {
   }, [state.flipped]);
 
   return (
-    <div id="tile-grid" className="container mt-5">
+    <div id="tile-grid" role="tile-grid" className="container mt-5">
       <div className="row">
         <div className="col-12 col-lg-10 col-md-12 offset-md-0 offset-lg-1">
           <div className="d-flex justify-content-center flex-wrap gap-3">

--- a/packages/frontend/src/components/Game/GameBoard/TileGrid/index.jsx
+++ b/packages/frontend/src/components/Game/GameBoard/TileGrid/index.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import Tile from '../Tile';
-import { flipTile, resetTiles } from 'contexts/game/actions';
+import { flipTile, handleMatch, resetTiles } from 'contexts/game/actions';
 import useGameContext from 'hooks/useGameContext';
 
 const TileGrid = ({ tiles }) => {
@@ -15,6 +15,7 @@ const TileGrid = ({ tiles }) => {
     if (state.flipped.length > 1) {
       if (state.flipped[0].photo.id === state.flipped[1].photo.id) {
         console.log('dispatch HANDLE_MATCH');
+        dispatch(handleMatch(state.flipped));
       } else {
         setTimeout(() => {
           dispatch(resetTiles(state.flipped));
@@ -22,7 +23,8 @@ const TileGrid = ({ tiles }) => {
       }
     }
   }, [state.flipped]);
-
+  console.log(state.tiles, 'Tiles from TG');
+  console.log(state.currentPlayer, 'CP');
   return (
     <div id="tile-grid" className="container mt-5">
       <div className="row">

--- a/packages/frontend/src/components/Game/GameBoard/TileGrid/index.jsx
+++ b/packages/frontend/src/components/Game/GameBoard/TileGrid/index.jsx
@@ -13,15 +13,19 @@ const TileGrid = ({ tiles }) => {
 
   useEffect(() => {
     if (state.flipped.length > 1) {
-      if (state.flipped[0].photo.id === state.flipped[1].photo.id) {
-        setTimeout(() => {
+      const timeout = setTimeout(() => {
+        if (state.flipped[0].photo.id === state.flipped[1].photo.id) {
           dispatch(handleMatch(state.flipped));
-        }, 2000);
-      } else {
-        setTimeout(() => {
+        } else {
           dispatch(resetTiles(state.flipped));
-        }, 2000);
-      }
+        }
+      }, 2000);
+
+      return () => {
+        if (timeout) {
+          clearTimeout(timeout);
+        }
+      };
     }
   }, [state.flipped]);
 

--- a/packages/frontend/src/components/Game/GameBoard/TileGrid/index.jsx
+++ b/packages/frontend/src/components/Game/GameBoard/TileGrid/index.jsx
@@ -26,7 +26,7 @@ const TileGrid = ({ tiles }) => {
   }, [state.flipped]);
 
   return (
-    <div id="tile-grid" role="tile-grid" className="container mt-5">
+    <div id="tile-grid" className="container mt-5">
       <div className="row">
         <div className="col-12 col-lg-10 col-md-12 offset-md-0 offset-lg-1">
           <div className="d-flex justify-content-center flex-wrap gap-3">

--- a/packages/frontend/src/components/Game/GameBoard/TileGrid/index.jsx
+++ b/packages/frontend/src/components/Game/GameBoard/TileGrid/index.jsx
@@ -15,7 +15,9 @@ const TileGrid = ({ tiles }) => {
     if (state.flipped.length > 1) {
       if (state.flipped[0].photo.id === state.flipped[1].photo.id) {
         console.log('dispatch HANDLE_MATCH');
-        dispatch(handleMatch(state.flipped));
+        setTimeout(() => {
+          dispatch(handleMatch(state.flipped));
+        }, 2000);
       } else {
         setTimeout(() => {
           dispatch(resetTiles(state.flipped));

--- a/packages/frontend/src/components/Game/GameBoard/TileGrid/index.jsx
+++ b/packages/frontend/src/components/Game/GameBoard/TileGrid/index.jsx
@@ -14,7 +14,6 @@ const TileGrid = ({ tiles }) => {
   useEffect(() => {
     if (state.flipped.length > 1) {
       if (state.flipped[0].photo.id === state.flipped[1].photo.id) {
-        console.log('dispatch HANDLE_MATCH');
         setTimeout(() => {
           dispatch(handleMatch(state.flipped));
         }, 2000);

--- a/packages/frontend/src/components/Game/GameBoard/TileGrid/index.jsx
+++ b/packages/frontend/src/components/Game/GameBoard/TileGrid/index.jsx
@@ -23,8 +23,7 @@ const TileGrid = ({ tiles }) => {
       }
     }
   }, [state.flipped]);
-  console.log(state.tiles, 'Tiles from TG');
-  console.log(state.currentPlayer, 'CP');
+
   return (
     <div id="tile-grid" className="container mt-5">
       <div className="row">

--- a/packages/frontend/src/components/Game/GameBoard/TileGrid/index.test.jsx
+++ b/packages/frontend/src/components/Game/GameBoard/TileGrid/index.test.jsx
@@ -2,8 +2,6 @@ import { setupTests } from 'helpers/tests';
 import { createTilesFromPhotos } from 'helpers/createTilesFromPhotos';
 import TileGrid from '.';
 import { mockPhotos } from '__mocks__/api/mockPhotos';
-import userEvent from '@testing-library/user-event';
-import { getByTestId } from '@testing-library/react';
 
 describe('TileGrid component', () => {
   it('renders all tiles', () => {
@@ -14,29 +12,5 @@ describe('TileGrid component', () => {
     const allTiles = screen.getAllByTestId(/tile/);
 
     expect(allTiles.length).toBe(10);
-  });
-
-  it('flips a tile after two seconds when onFlipTile is called', async () => {
-
-    const tiles = createTilesFromPhotos(mockPhotos, { shuffle: false });
-    const { screen } = setupTests(TileGrid, { props: { tiles } });
-    
-    screen.debug()
-    const tile = screen.getByTestId(/tile-1/);
-    screen.debug(tile);
-    
-    const user = userEvent.setup();
-
-    expect(tile).toHaveClass('faceDown');
-
-    await user.click(tile);
-    
-    //THIS SHOULD FAIL 
-    expect(screen.getByTestId(/tile-1/)).toHaveClass('faceDown');
-    
-    //NONE HAVE CHANGED
-    const allTiles = screen.getAllByTestId(/tile/);
-    screen.debug(allTiles)
-
   });
 });

--- a/packages/frontend/src/components/Game/GameBoard/TileGrid/index.test.jsx
+++ b/packages/frontend/src/components/Game/GameBoard/TileGrid/index.test.jsx
@@ -2,6 +2,7 @@ import { setupTests } from 'helpers/tests';
 import { createTilesFromPhotos } from 'helpers/createTilesFromPhotos';
 import TileGrid from '.';
 import { mockPhotos } from '__mocks__/api/mockPhotos';
+import userEvent from '@testing-library/user-event';
 
 describe('TileGrid component', () => {
   it('renders all tiles', () => {
@@ -12,5 +13,25 @@ describe('TileGrid component', () => {
     const allTiles = screen.getAllByTestId(/tile/);
 
     expect(allTiles.length).toBe(10);
+  });
+
+  it('flips a tile after two seconds when onFlipTile is called', async () => {
+
+    //setup the TileGrid component with tiles prop
+    const tiles = createTilesFromPhotos(mockPhotos);
+
+    const { screen } = setupTests(TileGrid, { props: { tiles } });
+    
+    
+    
+    const tile = screen.getByTestId('tile-1');
+    screen.debug(tile);
+    
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId('tile-1'));
+
+
+    // expect(onFlipTile).toHaveBeenCalledTimes(1);
+
   });
 });

--- a/packages/frontend/src/components/Game/GameBoard/TileGrid/index.test.jsx
+++ b/packages/frontend/src/components/Game/GameBoard/TileGrid/index.test.jsx
@@ -3,6 +3,7 @@ import { createTilesFromPhotos } from 'helpers/createTilesFromPhotos';
 import TileGrid from '.';
 import { mockPhotos } from '__mocks__/api/mockPhotos';
 import userEvent from '@testing-library/user-event';
+import { getByTestId } from '@testing-library/react';
 
 describe('TileGrid component', () => {
   it('renders all tiles', () => {
@@ -17,21 +18,25 @@ describe('TileGrid component', () => {
 
   it('flips a tile after two seconds when onFlipTile is called', async () => {
 
-    
-    const tiles = createTilesFromPhotos(mockPhotos);
-
+    const tiles = createTilesFromPhotos(mockPhotos, { shuffle: false });
     const { screen } = setupTests(TileGrid, { props: { tiles } });
     
-    
-    
-    const tile = screen.getByTestId('tile-1');
+    screen.debug()
+    const tile = screen.getByTestId(/tile-1/);
     screen.debug(tile);
     
     const user = userEvent.setup();
-    await user.click(screen.getByTestId('tile-1'));
 
+    expect(tile).toHaveClass('faceDown');
 
-    expect(onFlipTile).toHaveBeenCalledTimes(1);
+    await user.click(tile);
+    
+    //THIS SHOULD FAIL 
+    expect(screen.getByTestId(/tile-1/)).toHaveClass('faceDown');
+    
+    //NONE HAVE CHANGED
+    const allTiles = screen.getAllByTestId(/tile/);
+    screen.debug(allTiles)
 
   });
 });

--- a/packages/frontend/src/components/Game/GameBoard/TileGrid/index.test.jsx
+++ b/packages/frontend/src/components/Game/GameBoard/TileGrid/index.test.jsx
@@ -17,7 +17,7 @@ describe('TileGrid component', () => {
 
   it('flips a tile after two seconds when onFlipTile is called', async () => {
 
-    //setup the TileGrid component with tiles prop
+    
     const tiles = createTilesFromPhotos(mockPhotos);
 
     const { screen } = setupTests(TileGrid, { props: { tiles } });
@@ -31,7 +31,7 @@ describe('TileGrid component', () => {
     await user.click(screen.getByTestId('tile-1'));
 
 
-    // expect(onFlipTile).toHaveBeenCalledTimes(1);
+    expect(onFlipTile).toHaveBeenCalledTimes(1);
 
   });
 });

--- a/packages/frontend/src/components/Game/GameBoard/index.test.jsx
+++ b/packages/frontend/src/components/Game/GameBoard/index.test.jsx
@@ -43,17 +43,13 @@ describe('GameBoard component', () => {
   });
 
   const ui = {
-    tile1: {
-      container: byTestId('tile-1'),
-      photo: byAltText(/Jellyfish/),
-    },
-    tile2: {
-      container: byTestId('tile-5'),
-      photo: byAltText(/Splashing/),
+    tile: {
+      container: (testId) => byTestId(testId),
+      photo: (altText) => byAltText(altText),
     },
   };
 
-  const {tile1, tile2} = ui
+  const { tile } = ui
 
   it('unmatched tiles are flipped back after two seconds', async () => {
     const tiles = createTilesFromPhotos(mockPhotos, { shuffle: false });
@@ -65,20 +61,20 @@ describe('GameBoard component', () => {
 
     const { user } = setupTests(GameBoard, { state });
 
-    expect(tile1.container.get()).toHaveClass('faceDown');
+    expect(tile.container('tile-1').get()).toHaveClass('faceDown');
 
-    await user.click(tile1.container.get());
-    await user.click(tile2.container.get());
+    await user.click(tile.container('tile-1').get());
+    await user.click(tile.container('tile-5').get());
 
-    expect(tile1.photo.get()).toBeInTheDocument();
-    expect(tile2.photo.get()).toBeInTheDocument();
+    expect(tile.photo(tiles[1].photo.alt).get()).toBeInTheDocument();
+    expect(tile.photo(tiles[5].photo.alt).get()).toBeInTheDocument();
 
     act(() => jest.advanceTimersByTime(3000));
 
-    expect(tile1.container.get()).toHaveClass('faceDown');
-    expect(tile2.container.get()).toHaveClass('faceDown');
+    expect(tile.container('tile-1').get()).toHaveClass('faceDown');
+    expect(tile.container('tile-5').get()).toHaveClass('faceDown');
 
-    expect(tile1.photo.query()).toBeNull();
-    expect(tile2.photo.query()).toBeNull();
+    expect(tile.photo(tiles[1].photo.alt).query()).toBeNull();
+    expect(tile.photo(tiles[5].photo.alt).query()).toBeNull();
   });
 });

--- a/packages/frontend/src/components/Game/GameBoard/index.test.jsx
+++ b/packages/frontend/src/components/Game/GameBoard/index.test.jsx
@@ -1,5 +1,38 @@
+import { setupTests } from 'helpers/tests';
 import GameBoard from '.';
+import { mockPhotos } from '__mocks__/api/mockPhotos';
+import { createTilesFromPhotos } from 'helpers/createTilesFromPhotos';
+import { baseState } from 'contexts';
+import { produce } from 'immer';
+import userEvent from '@testing-library/user-event';
+
+
+
 
 describe('GameBoard component', () => {
-  it('', () => {});
+  it( 'flips the tile thats been clicked', async () => {
+    
+    const tiles = createTilesFromPhotos(mockPhotos, {shuffle: false});
+
+    const initialGameState = produce(baseState.game, (draft) => {
+      draft.tiles = tiles
+    })
+    const state = {...baseState, game: initialGameState };
+    
+    const { screen, user } = setupTests(GameBoard, { state });
+    screen.debug(initialGameState.game)
+    
+    const tileGrid = screen.getByRole('tile-grid')
+
+    const element = screen.getByTestId('tile-1')
+
+    await user.click(element);
+
+    const allTiles = screen.getAllByTestId(/tile/)
+    screen.debug(allTiles, 'ALL TILES')
+
+    expect(screen.getByTestId('tile-1')).not.toHaveClass('faceDown')
+
+    //assert that the grid has changed
+  });
 });

--- a/packages/frontend/src/components/Game/GameBoard/index.test.jsx
+++ b/packages/frontend/src/components/Game/GameBoard/index.test.jsx
@@ -4,22 +4,20 @@ import { mockPhotos } from '__mocks__/api/mockPhotos';
 import { createTilesFromPhotos } from 'helpers/createTilesFromPhotos';
 import { baseState } from 'contexts';
 import { produce } from 'immer';
+import { waitFor, act } from '@testing-library/react';
 
 beforeEach(() => {
-  jest.useFakeTimers('legacy')
-})
+  jest.useFakeTimers('legacy');
+});
 
 afterEach(() => {
-  // jest.runOnlyPendingTimers()
-  jest.useRealTimers()
-})
+  jest.useRealTimers();
+});
 
 jest.spyOn(global, 'setTimeout');
 
 describe('GameBoard component', () => {
-
   it('flips the tile thats been clicked', async () => {
-    
     const tiles = createTilesFromPhotos(mockPhotos, { shuffle: false });
 
     const initialGameState = produce(baseState.game, (draft) => {
@@ -33,10 +31,43 @@ describe('GameBoard component', () => {
 
     expect(screen.getByTestId('tile-1')).toHaveClass('faceDown');
     await user.click(element);
-    
-    
+
     jest.advanceTimersByTime(3000);
-    // expect(setTimeout).toHaveBeenCalledTimes(1);
+
+    const displayedImage = document.querySelector('img');
+
     expect(screen.getByTestId('tile-1')).not.toHaveClass('faceDown');
+    expect(screen.getByAltText(/Jellyfish/)).toBeInTheDocument();
+    expect(displayedImage).toBeInTheDocument();
+  });
+
+  it('unmatched tiles are flipped back after two seconds', async () => {
+    const tiles = createTilesFromPhotos(mockPhotos, { shuffle: false });
+
+    const initialGameState = produce(baseState.game, (draft) => {
+      draft.tiles = tiles;
+    });
+    const state = { ...baseState, game: initialGameState };
+
+    const { screen, user } = setupTests(GameBoard, { state });
+
+    const element1 = screen.getByTestId('tile-1');
+    const element2 = screen.getByTestId('tile-5');
+
+    expect(screen.getByTestId('tile-1')).toHaveClass('faceDown');
+
+    await user.click(element1);
+    await user.click(element2);
+
+    expect(screen.getByAltText(/Jellyfish/)).toBeInTheDocument();
+    expect(screen.getByAltText(/Splashing/)).toBeInTheDocument();
+
+    act(() => jest.advanceTimersByTime(3000));
+
+    expect(screen.getByTestId('tile-1')).toHaveClass('faceDown');
+    expect(screen.getByTestId('tile-5')).toHaveClass('faceDown');
+
+    expect(screen.queryByAltText(/Jellyfish/)).toBeNull();
+    expect(screen.queryByAltText(/Splashing/)).toBeNull();
   });
 });

--- a/packages/frontend/src/components/Game/GameBoard/index.test.jsx
+++ b/packages/frontend/src/components/Game/GameBoard/index.test.jsx
@@ -4,35 +4,39 @@ import { mockPhotos } from '__mocks__/api/mockPhotos';
 import { createTilesFromPhotos } from 'helpers/createTilesFromPhotos';
 import { baseState } from 'contexts';
 import { produce } from 'immer';
-import userEvent from '@testing-library/user-event';
 
+beforeEach(() => {
+  jest.useFakeTimers()
+})
 
+afterEach(() => {
+  jest.runOnlyPendingTimers()
+  jest.useRealTimers()
+})
 
+jest.spyOn(global, 'setTimeout');
 
 describe('GameBoard component', () => {
-  it( 'flips the tile thats been clicked', async () => {
+
+  it('flips the tile thats been clicked', async () => {
     
-    const tiles = createTilesFromPhotos(mockPhotos, {shuffle: false});
+    const tiles = createTilesFromPhotos(mockPhotos, { shuffle: false });
 
     const initialGameState = produce(baseState.game, (draft) => {
-      draft.tiles = tiles
-    })
-    const state = {...baseState, game: initialGameState };
-    
-    const { screen, user } = setupTests(GameBoard, { state });
-    screen.debug(initialGameState.game)
-    
-    const tileGrid = screen.getByRole('tile-grid')
+      draft.tiles = tiles;
+    });
+    const state = { ...baseState, game: initialGameState };
 
-    const element = screen.getByTestId('tile-1')
+    const { screen, user } = setupTests(GameBoard, { state });
+
+    const element = screen.getByTestId('tile-1');
 
     await user.click(element);
-
-    const allTiles = screen.getAllByTestId(/tile/)
-    screen.debug(allTiles, 'ALL TILES')
-
-    expect(screen.getByTestId('tile-1')).not.toHaveClass('faceDown')
-
-    //assert that the grid has changed
+    // expect(setTimeout).toHaveBeenCalledTimes(1);
+    // expect(screen.getByTestId('tile-1')).toHaveClass('faceDown');
+    
+    jest.advanceTimersByTime(3000);
+    expect(setTimeout).toHaveBeenCalledTimes(1);
+    // expect(screen.getByTestId('tile-1')).not.toHaveClass('faceDown');
   });
 });

--- a/packages/frontend/src/components/Game/GameBoard/index.test.jsx
+++ b/packages/frontend/src/components/Game/GameBoard/index.test.jsx
@@ -15,7 +15,14 @@ afterEach(() => {
   jest.useRealTimers();
 });
 
-jest.spyOn(global, 'setTimeout');
+const ui = {
+  tile: {
+    container: (testId) => byTestId(testId),
+    photo: (altText) => byAltText(altText),
+  },
+};
+
+const { tile } = ui
 
 describe('GameBoard component', () => {
   it('flips the tile thats been clicked', async () => {
@@ -28,28 +35,12 @@ describe('GameBoard component', () => {
 
     const { screen, user } = setupTests(GameBoard, { state });
 
-    const element = screen.getByTestId('tile-1');
+    expect(tile.container('tile-1').get()).toHaveClass('faceDown');
+    await user.click(tile.container('tile-1').get());
 
-    expect(screen.getByTestId('tile-1')).toHaveClass('faceDown');
-    await user.click(element);
-
-    jest.advanceTimersByTime(3000);
-
-    const displayedImage = document.querySelector('img');
-
-    expect(screen.getByTestId('tile-1')).not.toHaveClass('faceDown');
-    expect(screen.getByAltText(/Jellyfish/)).toBeInTheDocument();
-    expect(displayedImage).toBeInTheDocument();
+    expect(tile.container('tile-1').get()).not.toHaveClass('faceDown');
+    expect(tile.photo(tiles[1].photo.alt).get()).toBeInTheDocument();
   });
-
-  const ui = {
-    tile: {
-      container: (testId) => byTestId(testId),
-      photo: (altText) => byAltText(altText),
-    },
-  };
-
-  const { tile } = ui
 
   it('unmatched tiles are flipped back after two seconds', async () => {
     const tiles = createTilesFromPhotos(mockPhotos, { shuffle: false });

--- a/packages/frontend/src/components/Game/GameBoard/index.test.jsx
+++ b/packages/frontend/src/components/Game/GameBoard/index.test.jsx
@@ -43,11 +43,17 @@ describe('GameBoard component', () => {
   });
 
   const ui = {
-    tile1: byTestId('tile-1'),
-    tile2: byTestId('tile-5'),
-    tileAlt1: byAltText(/Jellyfish/),
-    tileAlt2: byAltText(/Splashing/),
+    tile1: {
+      container: byTestId('tile-1'),
+      photo: byAltText(/Jellyfish/),
+    },
+    tile2: {
+      container: byTestId('tile-5'),
+      photo: byAltText(/Splashing/),
+    },
   };
+
+  const {tile1, tile2} = ui
 
   it('unmatched tiles are flipped back after two seconds', async () => {
     const tiles = createTilesFromPhotos(mockPhotos, { shuffle: false });
@@ -59,20 +65,20 @@ describe('GameBoard component', () => {
 
     const { user } = setupTests(GameBoard, { state });
 
-    expect(ui.tile1.get()).toHaveClass('faceDown');
+    expect(tile1.container.get()).toHaveClass('faceDown');
 
-    await user.click(ui.tile1.get());
-    await user.click(ui.tile2.get());
+    await user.click(tile1.container.get());
+    await user.click(tile2.container.get());
 
-    expect(ui.tileAlt1.get()).toBeInTheDocument();
-    expect(ui.tileAlt2.get()).toBeInTheDocument();
+    expect(tile1.photo.get()).toBeInTheDocument();
+    expect(tile2.photo.get()).toBeInTheDocument();
 
     act(() => jest.advanceTimersByTime(3000));
 
-    expect(ui.tile1.get()).toHaveClass('faceDown');
-    expect(ui.tile2.get()).toHaveClass('faceDown');
+    expect(tile1.container.get()).toHaveClass('faceDown');
+    expect(tile2.container.get()).toHaveClass('faceDown');
 
-    expect(ui.tileAlt1.query()).toBeNull();
-    expect(ui.tileAlt2.query()).toBeNull();
+    expect(tile1.photo.query()).toBeNull();
+    expect(tile2.photo.query()).toBeNull();
   });
 });

--- a/packages/frontend/src/components/Game/GameBoard/index.test.jsx
+++ b/packages/frontend/src/components/Game/GameBoard/index.test.jsx
@@ -6,11 +6,11 @@ import { baseState } from 'contexts';
 import { produce } from 'immer';
 
 beforeEach(() => {
-  jest.useFakeTimers()
+  jest.useFakeTimers('legacy')
 })
 
 afterEach(() => {
-  jest.runOnlyPendingTimers()
+  // jest.runOnlyPendingTimers()
   jest.useRealTimers()
 })
 
@@ -31,12 +31,12 @@ describe('GameBoard component', () => {
 
     const element = screen.getByTestId('tile-1');
 
+    expect(screen.getByTestId('tile-1')).toHaveClass('faceDown');
     await user.click(element);
-    // expect(setTimeout).toHaveBeenCalledTimes(1);
-    // expect(screen.getByTestId('tile-1')).toHaveClass('faceDown');
+    
     
     jest.advanceTimersByTime(3000);
-    expect(setTimeout).toHaveBeenCalledTimes(1);
-    // expect(screen.getByTestId('tile-1')).not.toHaveClass('faceDown');
+    // expect(setTimeout).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('tile-1')).not.toHaveClass('faceDown');
   });
 });

--- a/packages/frontend/src/components/Game/GameBoard/index.test.jsx
+++ b/packages/frontend/src/components/Game/GameBoard/index.test.jsx
@@ -4,7 +4,8 @@ import { mockPhotos } from '__mocks__/api/mockPhotos';
 import { createTilesFromPhotos } from 'helpers/createTilesFromPhotos';
 import { baseState } from 'contexts';
 import { produce } from 'immer';
-import { waitFor, act } from '@testing-library/react';
+import { act } from '@testing-library/react';
+import { byTestId, byAltText } from 'testing-library-selector';
 
 beforeEach(() => {
   jest.useFakeTimers('legacy');
@@ -41,6 +42,13 @@ describe('GameBoard component', () => {
     expect(displayedImage).toBeInTheDocument();
   });
 
+  const ui = {
+    tile1: byTestId('tile-1'),
+    tile2: byTestId('tile-5'),
+    tileAlt1: byAltText(/Jellyfish/),
+    tileAlt2: byAltText(/Splashing/),
+  };
+
   it('unmatched tiles are flipped back after two seconds', async () => {
     const tiles = createTilesFromPhotos(mockPhotos, { shuffle: false });
 
@@ -49,25 +57,22 @@ describe('GameBoard component', () => {
     });
     const state = { ...baseState, game: initialGameState };
 
-    const { screen, user } = setupTests(GameBoard, { state });
+    const { user } = setupTests(GameBoard, { state });
 
-    const element1 = screen.getByTestId('tile-1');
-    const element2 = screen.getByTestId('tile-5');
+    expect(ui.tile1.get()).toHaveClass('faceDown');
 
-    expect(screen.getByTestId('tile-1')).toHaveClass('faceDown');
+    await user.click(ui.tile1.get());
+    await user.click(ui.tile2.get());
 
-    await user.click(element1);
-    await user.click(element2);
-
-    expect(screen.getByAltText(/Jellyfish/)).toBeInTheDocument();
-    expect(screen.getByAltText(/Splashing/)).toBeInTheDocument();
+    expect(ui.tileAlt1.get()).toBeInTheDocument();
+    expect(ui.tileAlt2.get()).toBeInTheDocument();
 
     act(() => jest.advanceTimersByTime(3000));
 
-    expect(screen.getByTestId('tile-1')).toHaveClass('faceDown');
-    expect(screen.getByTestId('tile-5')).toHaveClass('faceDown');
+    expect(ui.tile1.get()).toHaveClass('faceDown');
+    expect(ui.tile2.get()).toHaveClass('faceDown');
 
-    expect(screen.queryByAltText(/Jellyfish/)).toBeNull();
-    expect(screen.queryByAltText(/Splashing/)).toBeNull();
+    expect(ui.tileAlt1.query()).toBeNull();
+    expect(ui.tileAlt2.query()).toBeNull();
   });
 });

--- a/packages/frontend/src/components/Game/GameBoard/index.test.jsx
+++ b/packages/frontend/src/components/Game/GameBoard/index.test.jsx
@@ -65,7 +65,7 @@ describe('GameBoard component', () => {
     expect(tile.container('tile-1').get()).toHaveClass('faceDown');
     expect(tile.container('tile-5').get()).toHaveClass('faceDown');
 
-    expect(tile.photo(tiles[1].photo.alt).query()).toBeNull();
-    expect(tile.photo(tiles[5].photo.alt).query()).toBeNull();
+    expect(tile.photo(tiles[1].photo.alt).query()).not.toBeInTheDocument();
+    expect(tile.photo(tiles[5].photo.alt).query()).not.toBeInTheDocument();
   });
 });

--- a/packages/frontend/src/components/providers/game/index.jsx
+++ b/packages/frontend/src/components/providers/game/index.jsx
@@ -17,7 +17,7 @@ const GameProvider = ({ children, providedState = null } = {}) => {
   const { tiles } = state;
 
   useEffect(() => {
-    if (photos && !tiles) {
+    if (photos && tiles.length === 0) {
       dispatch(addTiles(photos));
     }
   }, [photos, tiles]);

--- a/packages/frontend/src/components/providers/game/index.jsx
+++ b/packages/frontend/src/components/providers/game/index.jsx
@@ -14,11 +14,13 @@ const GameProvider = ({ children, providedState = null } = {}) => {
     state: { photos },
   } = usePhotosContext();
 
+  const { tiles } = state;
+
   useEffect(() => {
-    if (photos) {
+    if (photos && !tiles) {
       dispatch(addTiles(photos));
     }
-  }, [photos]);
+  }, [photos, tiles]);
 
   return (
     <GameContext.Provider value={{ state, dispatch }}>

--- a/packages/frontend/src/contexts/game/index.js
+++ b/packages/frontend/src/contexts/game/index.js
@@ -19,6 +19,7 @@ export const initialGameState = {
       score: 0,
     },
   ],
+  tiles: [],
   flipped: [],
 };
 

--- a/packages/frontend/src/contexts/game/reducer/index.js
+++ b/packages/frontend/src/contexts/game/reducer/index.js
@@ -38,11 +38,17 @@ export const gameReducer = (state, action) => {
         flipped: [],
       };
 
-    // TODO:
-    // case types.HANDLE_MATCH:
-    //   return {
-    //     ...state,
-    //   };
+    case types.HANDLE_MATCH:
+      return {
+        ...state,
+        tiles: state.tiles.map((tile) =>
+          action.payload.tiles[0].id === tile.id ||
+          action.payload.tiles[1].id === tile.id
+            ? { ...tile, isMatched: !tile.isMatched }
+            : tile
+        ),
+        flipped: [],
+      };
 
     //TODO: reset game action to reset all tiles
 

--- a/packages/frontend/src/contexts/game/reducer/index.test.js
+++ b/packages/frontend/src/contexts/game/reducer/index.test.js
@@ -76,10 +76,8 @@ describe('gameReducer', () => {
       draft.flipped = [payload.tile];
     });
 
-    console.log(expected, 'EX');
     //delete this variable
     const result = gameReducer(initialTilesState, action);
-    console.log(result, 'RES');
     expect(gameReducer(initialTilesState, action)).toStrictEqual(expected);
   });
 

--- a/packages/frontend/src/helpers/tests.jsx
+++ b/packages/frontend/src/helpers/tests.jsx
@@ -16,7 +16,7 @@ const setupTests = (
   // push the route into the "browser" history
   window.history.pushState({}, 'Test', route);
 
-  const user = userEvent.setup();
+  const user = userEvent.setup({ delay: null });
   render(
     <BrowserRouter>
       <FormProvider providedState={{ ...state.form }}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -11252,6 +11252,11 @@ test-exclude@^6.0.0:
     glob "^7.1.4"
     minimatch "^3.0.4"
 
+testing-library-selector@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/testing-library-selector/-/testing-library-selector-0.3.1.tgz#ef4c2dfef356d7e0e1de458250d8311dae08af77"
+  integrity sha512-DjXyUhY/omIQNXnjOBFpkRaLADlf9yWDAW0KYpuNuurlS4aJNd1cE7yGG1XAH/LaMOSJ8woCkKdcO2UzyDAYQw==
+
 text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"


### PR DESCRIPTION
﻿## Description of changes 

When two flipped tiles have the same photo id, the handle match action is called, toggling the isMatched value for each tile and adding a matched class to each, removing them from game play. 

A test checking for the presence of the matched class when a tile's isMatched value is true is added. 

## Test steps
Click the tiles until you get a match. 
