### PR TITLE
69 add consolelog to eslint rules

### DIFF
--- a/packages/backend/.eslintrc.json
+++ b/packages/backend/.eslintrc.json
@@ -18,7 +18,8 @@
   "plugins": ["prettier", "react"],
   "extends": ["prettier", "eslint:recommended", "plugin:react/recommended"],
   "rules": {
-    "prettier/prettier": ["error", { "endOfLine": "auto" }]
+    "prettier/prettier": ["error", { "endOfLine": "auto" }],
+    "no-console": ["warn", { "allow": ["warn", "error"] }]
   },
   "settings": {
     "react": {

--- a/packages/backend/.eslintrc.json
+++ b/packages/backend/.eslintrc.json
@@ -19,7 +19,7 @@
   "extends": ["prettier", "eslint:recommended", "plugin:react/recommended"],
   "rules": {
     "prettier/prettier": ["error", { "endOfLine": "auto" }],
-    "no-console": ["warn", { "allow": ["warn", "error"] }]
+    "no-console": ["error", { "allow": ["warn", "error"] }]
   },
   "settings": {
     "react": {

--- a/packages/backend/app.js
+++ b/packages/backend/app.js
@@ -68,7 +68,7 @@ if (process.env.NODE_ENV !== 'test') {
     if (error) {
       console.error(error);
     } else {
-      console.log(`App is listening on port ${port}`);
+      console.warn(`App is listening on port ${port}`);
     }
   });
 }

--- a/packages/frontend/.eslintrc.json
+++ b/packages/frontend/.eslintrc.json
@@ -2,7 +2,8 @@
   "env": {
     "es6": true,
     "jest": true,
-    "node": true
+    "node": true,
+    "browser": true
   },
   "parser": "@babel/eslint-parser",
   "parserOptions": {

--- a/packages/frontend/.eslintrc.json
+++ b/packages/frontend/.eslintrc.json
@@ -20,7 +20,8 @@
   "plugins": ["prettier", "react"],
   "extends": ["prettier", "eslint:recommended", "plugin:react/recommended"],
   "rules": {
-    "prettier/prettier": ["error", { "endOfLine": "auto" }]
+    "prettier/prettier": ["error", { "endOfLine": "auto" }],
+    "no-console": ["error", { "allow": ["warn"] }]
   },
   "settings": {
     "react": {

--- a/packages/frontend/src/components/Game/GameBoard/TileGrid/index.jsx
+++ b/packages/frontend/src/components/Game/GameBoard/TileGrid/index.jsx
@@ -14,7 +14,7 @@ const TileGrid = ({ tiles }) => {
   useEffect(() => {
     if (state.flipped.length > 1) {
       if (state.flipped[0].photo.id === state.flipped[1].photo.id) {
-        console.log('dispatch HANDLE_MATCH');
+        // handle match
       } else {
         setTimeout(() => {
           dispatch(resetTiles(state.flipped));


### PR DESCRIPTION
﻿## Description of changes
- Added `no-console` rule to ESLint config, disallowing `console.log`, but allowing `console.warn` and `console.error` in the back end package and `console.warn` in the front end package

## Test steps
- (Re)Start both the front and back end servers
- In `backend/app.js`, add a `console.log`, `console.warn`, and `console.error`
- Verify that the warn and error statements are allowed, but the log statement shows as an error
- In `frontend/app.jsx`, add a `console.log`, `console.warn` and `console.error`.
- Verify that the warn statement is allowed, but the others are marked as linting errors