### PR TITLE
64 eslint change unused imports from errors to warnings

### DIFF
--- a/packages/backend/.eslintrc.json
+++ b/packages/backend/.eslintrc.json
@@ -20,7 +20,7 @@
   "rules": {
     "prettier/prettier": ["error", { "endOfLine": "auto" }],
     "no-unused-vars": "off",
-    "unused-imports/no-unused-imports": "warn",
+    "unused-imports/no-unused-imports": "error",
     "unused-imports/no-unused-vars": [
       "warn",
       {

--- a/packages/backend/.eslintrc.json
+++ b/packages/backend/.eslintrc.json
@@ -20,7 +20,7 @@
   "rules": {
     "prettier/prettier": ["error", { "endOfLine": "auto" }],
     "no-unused-vars": "off",
-    "unused-imports/no-unused-imports": "error",
+    "unused-imports/no-unused-imports": "warn",
     "unused-imports/no-unused-vars": [
       "warn",
       {

--- a/packages/backend/.eslintrc.json
+++ b/packages/backend/.eslintrc.json
@@ -15,10 +15,21 @@
       "modules": true
     }
   },
-  "plugins": ["prettier", "react"],
+  "plugins": ["prettier", "react", "unused-imports"],
   "extends": ["prettier", "eslint:recommended", "plugin:react/recommended"],
   "rules": {
-    "prettier/prettier": ["error", { "endOfLine": "auto" }]
+    "prettier/prettier": ["error", { "endOfLine": "auto" }],
+    "no-unused-vars": "warn",
+    "unused-imports/no-unused-imports": "error",
+    "unused-imports/no-unused-vars": [
+      "warn",
+      {
+        "vars": "all",
+        "varsIgnorePattern": "^_",
+        "args": "after-used",
+        "argsIgnorePattern": "^_"
+      }
+    ]
   },
   "settings": {
     "react": {

--- a/packages/backend/.eslintrc.json
+++ b/packages/backend/.eslintrc.json
@@ -19,7 +19,7 @@
   "extends": ["prettier", "eslint:recommended", "plugin:react/recommended"],
   "rules": {
     "prettier/prettier": ["error", { "endOfLine": "auto" }],
-    "no-unused-vars": "warn",
+    "no-unused-vars": "off",
     "unused-imports/no-unused-imports": "error",
     "unused-imports/no-unused-vars": [
       "warn",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -29,6 +29,7 @@
     "dotenv": "^16.3.1",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-react": "^7.33.2",
+    "eslint-plugin-unused-imports": "^3.0.0",
     "jest": "^29.6.4",
     "msw": "^1.2.5",
     "nodemon": "^3.0.1",

--- a/packages/frontend/.eslintrc.json
+++ b/packages/frontend/.eslintrc.json
@@ -17,10 +17,28 @@
       "presets": ["@babel/preset-react"]
     }
   },
-  "plugins": ["prettier", "react"],
-  "extends": ["prettier", "eslint:recommended", "plugin:react/recommended"],
+  "plugins": ["prettier", "react", "unused-imports"],
+  "extends": [
+    "react-app",
+    "prettier",
+    "eslint:recommended",
+    "plugin:react/recommended"
+  ],
   "rules": {
-    "prettier/prettier": ["error", { "endOfLine": "auto" }]
+    "prettier/prettier": ["error", { "endOfLine": "auto" }],
+    "react/jsx-uses-react": "warn",
+    "react/jsx-uses-vars": "warn",
+    "no-unused-vars": "warn",
+    "unused-imports/no-unused-imports": "error",
+    "unused-imports/no-unused-vars": [
+      "warn",
+      {
+        "vars": "all",
+        "varsIgnorePattern": "^_",
+        "args": "after-used",
+        "argsIgnorePattern": "^_"
+      }
+    ]
   },
   "settings": {
     "react": {

--- a/packages/frontend/.eslintrc.json
+++ b/packages/frontend/.eslintrc.json
@@ -28,7 +28,7 @@
     "prettier/prettier": ["error", { "endOfLine": "auto" }],
     "react/jsx-uses-react": "warn",
     "react/jsx-uses-vars": "warn",
-    "no-unused-vars": "warn",
+    "no-unused-vars": "off",
     "unused-imports/no-unused-imports": "error",
     "unused-imports/no-unused-vars": [
       "warn",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -52,6 +52,7 @@
     "@babel/preset-react": "^7.22.15",
     "dotenv": "^16.3.1",
     "eslint-plugin-prettier": "^5.0.0",
+    "eslint-plugin-unused-imports": "^3.0.0",
     "msw": "^1.3.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5218,6 +5218,18 @@ eslint-plugin-testing-library@^5.0.1:
   dependencies:
     "@typescript-eslint/utils" "^5.58.0"
 
+eslint-plugin-unused-imports@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-3.0.0.tgz#d25175b0072ff16a91892c3aa72a09ca3a9e69e7"
+  integrity sha512-sduiswLJfZHeeBJ+MQaG+xYzSWdRXoSw61DpU13mzWumCkR0ufD0HmO4kdNokjrkluMHpj/7PJeN35pgbhW3kw==
+  dependencies:
+    eslint-rule-composer "^0.3.0"
+
+eslint-rule-composer@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz#79320c927b0c5c0d3d3d2b76c8b4a488f25bbaf9"
+  integrity sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==
+
 eslint-scope@5.1.1, eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz"


### PR DESCRIPTION
﻿## Description of changes
- Installed and configured the `eslint-plugin-unused-imports` ESLint plugin


## Test steps
- Stop the front and back end dev servers if they're running
- Run `yarn install` in both packages
- Start the servers again
- Open `backend/app.js` and comment out the reference to `getDirName` as pictured below.
- Verify that the linting error for no unused imports appears
- Open `frontend/app.jsx` and comment out the reference to the `Game` component as pictured below.
- Verify that the linting error for no unused imports appears

|backend|frontend|
|-|-|
|![image](https://github.com/perennialAutodidact/memory-snap/assets/56051123/c50e016d-76fe-41f0-b44c-3dadc3b0f0b6)|![image](https://github.com/perennialAutodidact/memory-snap/assets/56051123/fcef6622-2e7b-46cf-8655-0c5b7d99ae28)|