### PR TITLE
check for match before changing current player

### DIFF
--- a/packages/frontend/src/components/Game/GameBoard/index.test.jsx
+++ b/packages/frontend/src/components/Game/GameBoard/index.test.jsx
@@ -135,28 +135,6 @@ describe('GameBoard component', () => {
       expect(updatedScore).toHaveTextContent('0');
     });
 
-    it('changes the active player after each turn', async () => {
-      const tiles = createTilesFromPhotos(mockPhotos, { shuffle: false });
-
-      const initialGameState = produce(baseState.game, (draft) => {
-        draft.tiles = tiles;
-      });
-
-      const state = { ...baseState, game: initialGameState };
-
-      const { user } = setupTests(GameBoard, { state });
-
-      expect(player.turnIndicator('Player 1').get()).toBeInTheDocument();
-
-      await user.click(tile.container('tile-5').get());
-      await user.click(tile.container('tile-2').get());
-      act(() => jest.advanceTimersByTime(3000));
-
-      expect(player.turnIndicator('Player 1').query()).toBeNull();
-
-      expect(player.turnIndicator('Player 2').get()).toBeInTheDocument();
-    });
-
     it('removes tiles and awards a point after a match', async () => {
       const tiles = createTilesFromPhotos(mockPhotos, { shuffle: false });
 
@@ -184,6 +162,73 @@ describe('GameBoard component', () => {
 
       const updatedPlayerOneScore = screen.getByTestId('player-score-1');
       expect(updatedPlayerOneScore).toHaveTextContent('1');
+    });
+
+    it('will not flip a tile if two others are flipped', async () => {
+      const tiles = createTilesFromPhotos(mockPhotos, { shuffle: false });
+
+      const initialGameState = produce(baseState.game, (draft) => {
+        draft.tiles = tiles;
+      });
+
+      const state = { ...baseState, game: initialGameState };
+
+      const { user } = setupTests(GameBoard, { state });
+
+      expect(tile.container('tile-0').get()).not.toHaveClass('faceUp');
+
+      await user.click(tile.container('tile-0').get());
+
+      expect(tile.container('tile-0').get()).toHaveClass('faceUp');
+
+      expect(tile.container('tile-5').get()).not.toHaveClass('faceUp');
+
+      await user.click(tile.container('tile-5').get());
+
+      expect(tile.container('tile-5').get()).toHaveClass('faceUp');
+
+      await user.click(tile.container('tile-7').get());
+      expect(tile.container('tile-7').get()).not.toHaveClass('faceUp');
+    });
+
+    it('does not change the current player if a match is made', async () => {
+      const tiles = createTilesFromPhotos(mockPhotos, { shuffle: false });
+
+      const initialGameState = produce(baseState.game, (draft) => {
+        draft.tiles = tiles;
+      });
+
+      const state = { ...baseState, game: initialGameState };
+
+      const { user } = setupTests(GameBoard, { state });
+
+      expect(player.turnIndicator('Player 1').get()).toBeInTheDocument();
+
+      await user.click(tile.container('tile-0').get());
+      await user.click(tile.container('tile-1').get());
+
+      expect(player.turnIndicator('Player 1').get()).toBeInTheDocument();
+    });
+
+    it('changes the current player if a match is not made', async () => {
+      const tiles = createTilesFromPhotos(mockPhotos, { shuffle: false });
+
+      const initialGameState = produce(baseState.game, (draft) => {
+        draft.tiles = tiles;
+      });
+
+      const state = { ...baseState, game: initialGameState };
+
+      const { user } = setupTests(GameBoard, { state });
+
+      expect(player.turnIndicator('Player 1').get()).toBeInTheDocument();
+
+      await user.click(tile.container('tile-0').get());
+      await user.click(tile.container('tile-3').get());
+
+      act(() => jest.advanceTimersByTime(3000));
+
+      expect(player.turnIndicator('Player 2').get()).toBeInTheDocument();
     });
   });
 });

--- a/packages/frontend/src/contexts/game/reducer/index.js
+++ b/packages/frontend/src/contexts/game/reducer/index.js
@@ -69,7 +69,9 @@ export const gameReducer = (state, action) => {
         players: isMatchingPair(state.flipped)
           ? awardPoint(state.players, state.currentPlayer.number - 1)
           : state.players,
-        turnCount: state.turnCount + 1,
+        turnCount: isMatchingPair(state.flipped)
+          ? state.turnCount
+          : state.turnCount + 1,
         stage:
           state.tiles.length !== 0 &&
           tempMatchedTiles.length === state.tiles.length

--- a/packages/frontend/src/contexts/game/reducer/index.js
+++ b/packages/frontend/src/contexts/game/reducer/index.js
@@ -63,7 +63,9 @@ export const gameReducer = (state, action) => {
         tiles: tempState.tiles,
         flipped: [],
         matchedTiles: tempMatchedTiles,
-        currentPlayer: state.players[state.turnCount % state.players.length],
+        currentPlayer: isMatchingPair(state.flipped)
+          ? state.currentPlayer
+          : state.players[state.turnCount % state.players.length],
         players: isMatchingPair(state.flipped)
           ? awardPoint(state.players, state.currentPlayer.number - 1)
           : state.players,

--- a/packages/frontend/src/contexts/game/reducer/index.test.js
+++ b/packages/frontend/src/contexts/game/reducer/index.test.js
@@ -130,4 +130,50 @@ describe('gameReducer', () => {
 
     expect(gameReducer(gameOverState, action).winner).toBe(null);
   });
+
+  it('does not change the current player when a match is made', () => {
+    const { game: state } = baseState;
+
+    const tiles = createTilesFromPhotos(mockPhotos, false).slice(0, 2);
+
+    const gameOverState = produce(state, (draft) => {
+      draft.flipped = tiles;
+    });
+
+    expect(state.currentPlayer.name).toBe('Player 1');
+
+    const payload = { tiles };
+
+    const action = {
+      type: 'HANDLE_FLIPPED_PAIR',
+      payload: payload,
+    };
+
+    expect(gameReducer(gameOverState, action).currentPlayer.name).toBe(
+      'Player 1'
+    );
+  });
+
+  it('changes the current player when no match is made', () => {
+    const { game: state } = baseState;
+
+    const tiles = createTilesFromPhotos(mockPhotos, false).slice(1, 3);
+
+    const gameOverState = produce(state, (draft) => {
+      draft.flipped = tiles;
+    });
+
+    expect(state.currentPlayer.name).toBe('Player 1');
+
+    const payload = { tiles };
+
+    const action = {
+      type: 'HANDLE_FLIPPED_PAIR',
+      payload: payload,
+    };
+
+    expect(gameReducer(gameOverState, action).currentPlayer.name).toBe(
+      'Player 2'
+    );
+  });
 });


### PR DESCRIPTION
﻿## Description of changes 
Now in the handle flipped pair reducer action, we check for a match before changing the current player. If its a match, the current player stays the same, if not, the current player advances. 


## Test steps
Play the game and check that the current player stays the same after a match is made. 