### PR TITLE
78 reset game

### DIFF
--- a/packages/frontend/src/components/Button/index.jsx
+++ b/packages/frontend/src/components/Button/index.jsx
@@ -1,9 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const Button = ({ text, color, onClick }) => {
+const Button = ({ text, color, textColor, onClick }) => {
   return (
-    <button onClick={onClick} type="submit" className={`btn btn-${color}`}>
+    <button
+      onClick={onClick}
+      type="submit"
+      className={`btn text-${textColor} btn-${color}`}
+    >
       {text}
     </button>
   );
@@ -12,6 +16,7 @@ const Button = ({ text, color, onClick }) => {
 Button.propTypes = {
   text: PropTypes.string,
   color: PropTypes.string,
+  textColor: PropTypes.string,
   onClick: PropTypes.func,
 };
 

--- a/packages/frontend/src/components/Button/index.jsx
+++ b/packages/frontend/src/components/Button/index.jsx
@@ -1,11 +1,18 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
-const Button = ({ text, color }) => {
+const Button = ({ text, color, onClick }) => {
   return (
-    <button type="submit" className={`btn btn-${color}`}>
+    <button onClick={onClick} type="submit" className={`btn btn-${color}`}>
       {text}
     </button>
   );
+};
+
+Button.propTypes = {
+  text: PropTypes.string,
+  color: PropTypes.string,
+  onClick: PropTypes.func,
 };
 
 export default Button;

--- a/packages/frontend/src/components/Game/GameBoard/ResultDisplay/index.jsx
+++ b/packages/frontend/src/components/Game/GameBoard/ResultDisplay/index.jsx
@@ -10,21 +10,21 @@ import { resetPhotos } from 'contexts/photos/actions';
 const ResultDisplay = () => {
   const {
     state: { winner, stage },
-    dispatch,
+    dispatch: gameDispatch,
   } = useGameContext();
 
-  const formValues = useFormContext();
-  const photoValues = usePhotosContext();
+  const { dispatch: formDispatch } = useFormContext();
+  const { dispatch: photoDispatch } = usePhotosContext();
 
   const handleReset = () => {
-    photoValues.dispatch(resetPhotos());
-    dispatch(resetGame());
-    formValues.dispatch(resetForm());
+    photoDispatch(resetPhotos());
+    gameDispatch(resetGame());
+    formDispatch(resetForm());
   };
 
   const handlePlayAgain = () => {
-    dispatch(resetGame());
-    dispatch(updateStage(1));
+    gameDispatch(resetGame());
+    gameDispatch(updateStage(1));
   };
 
   return (

--- a/packages/frontend/src/components/Game/GameBoard/ResultDisplay/index.jsx
+++ b/packages/frontend/src/components/Game/GameBoard/ResultDisplay/index.jsx
@@ -43,16 +43,20 @@ const ResultDisplay = () => {
               {`${winner.name} wins!`}
             </h2>
           )}
-          <Button
-            onClick={handlePlayAgain}
-            text={'play again'}
-            color={'primary'}
-          />
-          <Button
-            onClick={handleReset}
-            text={'reset game'}
-            color={'secondary'}
-          />
+          <div className="container d-flex flex-column pt-3">
+            <Button
+              onClick={handlePlayAgain}
+              text={'play again'}
+              color={'primary-dark'}
+              textColor={'primary'}
+            />
+            <Button
+              onClick={handleReset}
+              text={'reset game'}
+              color={'primary-dark'}
+              textColor={'secondary'}
+            />
+          </div>
         </div>
       </div>
     )

--- a/packages/frontend/src/components/Game/GameBoard/ResultDisplay/index.jsx
+++ b/packages/frontend/src/components/Game/GameBoard/ResultDisplay/index.jsx
@@ -1,28 +1,43 @@
 import React from 'react';
 import useGameContext from 'hooks/useGameContext';
+import useFormContext from 'hooks/useFormContext';
+import Button from 'components/Button';
+import { resetGame } from '../../../../contexts/game/actions/';
+import { resetForm } from 'contexts/form/actions';
 
 const ResultDisplay = () => {
   const {
-    state: { winner },
+    state: { winner, stage },
+    dispatch,
   } = useGameContext();
 
-  return (
-    <div
-      data-testid="result-display"
-      className="container d-flex justify-content-center pt-5"
-    >
-      <div className="d-flex-column text-center">
-        <h1 className="mb-5">GAME OVER!</h1>
+  const formValues = useFormContext();
 
-        {winner === null ? (
-          <h2 className="lh-lg">Its a tie!</h2>
-        ) : (
-          <h2 className={`text-${winner.color.className}`}>
-            {`${winner.name} wins!`}
-          </h2>
-        )}
+  const handleReset = () => {
+    dispatch(resetGame());
+    formValues.dispatch(resetForm());
+  };
+
+  return (
+    stage === 2 && (
+      <div
+        data-testid="result-display"
+        className="container d-flex justify-content-center pt-5"
+      >
+        <div className="d-flex-column text-center">
+          <h1 className="mb-5">GAME OVER!</h1>
+
+          {winner === null ? (
+            <h2 className="lh-lg">Its a tie!</h2>
+          ) : (
+            <h2 className={`text-${winner.color.className}`}>
+              {`${winner.name} wins!`}
+            </h2>
+          )}
+          <Button onClick={handleReset} text={'reset game'} color={'primary'} />
+        </div>
       </div>
-    </div>
+    )
   );
 };
 

--- a/packages/frontend/src/components/Game/GameBoard/ResultDisplay/index.jsx
+++ b/packages/frontend/src/components/Game/GameBoard/ResultDisplay/index.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import useGameContext from 'hooks/useGameContext';
 import useFormContext from 'hooks/useFormContext';
+import usePhotosContext from 'hooks/usePhotosContext';
 import Button from 'components/Button';
-import { resetGame } from '../../../../contexts/game/actions/';
+import { resetGame, updateStage } from '../../../../contexts/game/actions/';
 import { resetForm } from 'contexts/form/actions';
+import { resetPhotos } from 'contexts/photos/actions';
 
 const ResultDisplay = () => {
   const {
@@ -12,10 +14,17 @@ const ResultDisplay = () => {
   } = useGameContext();
 
   const formValues = useFormContext();
+  const photoValues = usePhotosContext();
 
   const handleReset = () => {
+    photoValues.dispatch(resetPhotos());
     dispatch(resetGame());
     formValues.dispatch(resetForm());
+  };
+
+  const handlePlayAgain = () => {
+    dispatch(resetGame());
+    dispatch(updateStage(1));
   };
 
   return (
@@ -34,7 +43,16 @@ const ResultDisplay = () => {
               {`${winner.name} wins!`}
             </h2>
           )}
-          <Button onClick={handleReset} text={'reset game'} color={'primary'} />
+          <Button
+            onClick={handlePlayAgain}
+            text={'play again'}
+            color={'primary'}
+          />
+          <Button
+            onClick={handleReset}
+            text={'reset game'}
+            color={'secondary'}
+          />
         </div>
       </div>
     )

--- a/packages/frontend/src/components/providers/photos/index.jsx
+++ b/packages/frontend/src/components/providers/photos/index.jsx
@@ -19,6 +19,7 @@ const PhotosProvider = ({ children, providedState = null } = {}) => {
   const { error, photos, status } = useFetchedPhotos({
     query: formValues.imageSearchTerm,
     perPage: formValues.tileNumber / 2,
+    storedPhotos: state.photos,
   });
 
   useEffect(() => {

--- a/packages/frontend/src/components/providers/photos/index.jsx
+++ b/packages/frontend/src/components/providers/photos/index.jsx
@@ -19,7 +19,6 @@ const PhotosProvider = ({ children, providedState = null } = {}) => {
   const { error, photos, status } = useFetchedPhotos({
     query: formValues.imageSearchTerm,
     perPage: formValues.tileNumber / 2,
-    storedPhotos: state.photos,
   });
 
   useEffect(() => {

--- a/packages/frontend/src/contexts/form/actions/index.js
+++ b/packages/frontend/src/contexts/form/actions/index.js
@@ -4,3 +4,7 @@ export const updateForm = value => ({
   type: types.UPDATE_FORM,
   payload: value,
 });
+
+export const resetForm = () => ({
+  type: types.RESET_FORM,
+});

--- a/packages/frontend/src/contexts/form/actions/types.js
+++ b/packages/frontend/src/contexts/form/actions/types.js
@@ -1,7 +1,9 @@
 const UPDATE_FORM = 'UPDATE_FORM';
+const RESET_FORM = 'RESET_FORM';
 
 const types = {
   UPDATE_FORM,
+  RESET_FORM,
 };
 
 export default types;

--- a/packages/frontend/src/contexts/form/reducer/index.js
+++ b/packages/frontend/src/contexts/form/reducer/index.js
@@ -24,6 +24,7 @@ export const formReducer = (state, action) => {
       return {
         ...initialFormState,
         currentStep: 1,
+        formValues: { imageSearchTerm: null },
       };
     }
 

--- a/packages/frontend/src/contexts/form/reducer/index.js
+++ b/packages/frontend/src/contexts/form/reducer/index.js
@@ -1,4 +1,5 @@
 import types from 'contexts/form/actions/types';
+import { initialFormState } from '../';
 
 export const formReducer = (state, action) => {
   if (!state) {
@@ -16,6 +17,13 @@ export const formReducer = (state, action) => {
           ...state.formValues,
           ...action.payload,
         },
+      };
+    }
+
+    case types.RESET_FORM: {
+      return {
+        ...initialFormState,
+        currentStep: 1,
       };
     }
 

--- a/packages/frontend/src/contexts/game/actions/index.js
+++ b/packages/frontend/src/contexts/game/actions/index.js
@@ -23,3 +23,7 @@ export const handleFlippedPair = tiles => ({
 export const handleGameOver = () => ({
   type: types.HANDLE_GAME_OVER,
 });
+
+export const resetGame = () => ({
+  type: types.RESET_GAME,
+});

--- a/packages/frontend/src/contexts/game/actions/types.js
+++ b/packages/frontend/src/contexts/game/actions/types.js
@@ -3,6 +3,7 @@ const ADD_TILES = 'ADD_TILES';
 const FLIP_TILE = 'FLIP_TILE';
 const HANDLE_FLIPPED_PAIR = 'HANDLE_FLIPPED_PAIR';
 const HANDLE_GAME_OVER = 'HANDLE_GAME_OVER';
+const RESET_GAME = 'RESET_GAME';
 
 const types = {
   UPDATE_STAGE,
@@ -10,6 +11,7 @@ const types = {
   FLIP_TILE,
   HANDLE_FLIPPED_PAIR,
   HANDLE_GAME_OVER,
+  RESET_GAME,
 };
 
 export default types;

--- a/packages/frontend/src/contexts/game/reducer/index.js
+++ b/packages/frontend/src/contexts/game/reducer/index.js
@@ -9,6 +9,7 @@ import {
   awardPoint,
   getHighScore,
 } from 'helpers';
+import { initialGameState } from '../../../contexts/game';
 
 export const gameReducer = (state, action) => {
   if (!state) {
@@ -93,6 +94,12 @@ export const gameReducer = (state, action) => {
       return {
         ...state,
         winner: highScore.length > 1 ? null : highScore[0],
+      };
+    }
+
+    case types.RESET_GAME: {
+      return {
+        ...initialGameState,
       };
     }
 

--- a/packages/frontend/src/contexts/photos/actions/index.js
+++ b/packages/frontend/src/contexts/photos/actions/index.js
@@ -1,6 +1,6 @@
 import types from './types';
 
-export const setError = (error) => {
+export const setError = error => {
   const message = 'An error message is required.';
   if (!error) throw new Error(message);
 
@@ -10,7 +10,7 @@ export const setError = (error) => {
   };
 };
 
-export const setPhotos = (photos) => {
+export const setPhotos = photos => {
   if (!Array.isArray(photos)) throw new TypeError('photos must be an array');
 
   return {
@@ -19,7 +19,13 @@ export const setPhotos = (photos) => {
   };
 };
 
-export const setStatus = (status) => {
+export const resetPhotos = () => {
+  return {
+    type: types.RESET_PHOTOS,
+  };
+};
+
+export const setStatus = status => {
   const allowedStatuses = ['ERROR', 'IDLE', 'PENDING', 'SUCCESS'];
 
   if (!allowedStatuses.includes(status)) {

--- a/packages/frontend/src/contexts/photos/actions/types.js
+++ b/packages/frontend/src/contexts/photos/actions/types.js
@@ -1,9 +1,13 @@
 const SET_ERROR = 'SET_ERROR';
 const SET_PHOTOS = 'SET_PHOTOS';
+const RESET_PHOTOS = 'RESET_PHOTOS';
 const SET_STATUS = 'SET_STATUS';
 
-export default {
+const types = {
   SET_ERROR,
   SET_PHOTOS,
+  RESET_PHOTOS,
   SET_STATUS,
 };
+
+export default types;

--- a/packages/frontend/src/contexts/photos/reducer/index.js
+++ b/packages/frontend/src/contexts/photos/reducer/index.js
@@ -22,6 +22,13 @@ export const photosReducer = (state, action) => {
       };
     }
 
+    case types.RESET_PHOTOS: {
+      return {
+        ...state,
+        photos: null,
+      };
+    }
+
     case types.SET_STATUS: {
       return {
         ...state,

--- a/packages/frontend/src/hooks/useFetchedPhotos/index.jsx
+++ b/packages/frontend/src/hooks/useFetchedPhotos/index.jsx
@@ -1,9 +1,15 @@
 import { useEffect, useState } from 'react';
 
-const useFetchedPhotos = ({ query = null, perPage }) => {
+const useFetchedPhotos = ({ query = null, perPage, storedPhotos }) => {
   const [photos, setPhotos] = useState(null);
   const [photosError, setPhotosError] = useState(null);
   const [status, setStatus] = useState('IDLE');
+
+  useEffect(() => {
+    if (storedPhotos === null) {
+      setPhotos(null);
+    }
+  }, [storedPhotos]);
 
   useEffect(() => {
     if (!photos && !photosError && query !== null) {
@@ -38,7 +44,6 @@ const useFetchedPhotos = ({ query = null, perPage }) => {
       })();
     }
   }, [photosError, status, perPage, photos, query]);
-
   return { photos, error: photosError, status };
 };
 

--- a/packages/frontend/src/hooks/useFetchedPhotos/index.jsx
+++ b/packages/frontend/src/hooks/useFetchedPhotos/index.jsx
@@ -1,15 +1,15 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useReducer } from 'react';
+import { baseState } from 'contexts';
+import { setPhotos } from 'contexts/photos/actions';
+import { photosReducer } from 'contexts/photos/reducer';
 
-const useFetchedPhotos = ({ query = null, perPage, storedPhotos }) => {
-  const [photos, setPhotos] = useState(null);
+const useFetchedPhotos = ({ query = null, perPage }) => {
   const [photosError, setPhotosError] = useState(null);
   const [status, setStatus] = useState('IDLE');
+  const initialState = baseState.photos;
+  const [state, dispatch] = useReducer(photosReducer, initialState);
 
-  useEffect(() => {
-    if (storedPhotos === null) {
-      setPhotos(null);
-    }
-  }, [storedPhotos]);
+  const photos = state.photos;
 
   useEffect(() => {
     if (!photos && !photosError && query !== null) {
@@ -27,7 +27,7 @@ const useFetchedPhotos = ({ query = null, perPage, storedPhotos }) => {
           if (!data.error) {
             if (!photos) {
               setStatus('SUCCESS');
-              setPhotos(data.photos);
+              dispatch(setPhotos(data.photos));
             }
           } else {
             if (!photosError) {
@@ -43,7 +43,7 @@ const useFetchedPhotos = ({ query = null, perPage, storedPhotos }) => {
         }
       })();
     }
-  }, [photosError, status, perPage, photos, query]);
+  }, [photosError, photos, perPage, status, query]);
   return { photos, error: photosError, status };
 };
 

--- a/packages/frontend/src/hooks/useFetchedPhotos/index.jsx
+++ b/packages/frontend/src/hooks/useFetchedPhotos/index.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, useReducer } from 'react';
 import { baseState } from 'contexts';
-import { setPhotos } from 'contexts/photos/actions';
+import { setPhotos, resetPhotos } from 'contexts/photos/actions';
 import { photosReducer } from 'contexts/photos/reducer';
 
 const useFetchedPhotos = ({ query = null, perPage }) => {
@@ -10,6 +10,12 @@ const useFetchedPhotos = ({ query = null, perPage }) => {
   const [state, dispatch] = useReducer(photosReducer, initialState);
 
   const photos = state.photos;
+
+  useEffect(() => {
+    if (query === null) {
+      dispatch(resetPhotos());
+    }
+  }, [photos, query]);
 
   useEffect(() => {
     if (!photos && !photosError && query !== null) {
@@ -43,7 +49,7 @@ const useFetchedPhotos = ({ query = null, perPage }) => {
         }
       })();
     }
-  }, [photosError, photos, perPage, status, query]);
+  }, [photosError, photos, perPage, status, query, state]);
   return { photos, error: photosError, status };
 };
 


### PR DESCRIPTION
﻿## Description of changes 
This branch adds a PLAY AGAIN button which lets players play the same game over with the same set of photos reshuffled in a different order, and a RESET GAME button that lets players start the game over again at the setup stage, reentering all the game values. 


## Test steps
Play a game and hit the play again button to ensure that the players names and photos have all stayed in the game, and that the photos have reshuffled. The game should be playable again as normal, with both scores starting at zero. 

Play again and hit the reset button. Ensure that the game takes you back to the setup stage, where you should be able to enter all the form values again and play a new game. 

## Future Considerations
This seems fine to me for an MVP, but there could be a version in the future that lets players keep their names and only reset the type and number of photos desired. 

There are no tests written for this PR currently and will be done as next steps. 
