### PR TITLE
90 tiles extend off the bottom of the screen

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -9,6 +9,7 @@
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^14.4.3",
+    "@uidotdev/usehooks": "^2.4.1",
     "bootstrap": "^5.3.1",
     "express": "^4.18.2",
     "gsap": "^3.12.2",

--- a/packages/frontend/src/App.jsx
+++ b/packages/frontend/src/App.jsx
@@ -1,5 +1,4 @@
 import React, { useEffect } from 'react';
-// import { BreakpointContext } from 'contexts/breakpoint';
 import { useLocation } from 'react-router-dom';
 import './styles/App.scss';
 import { Routes, Route, useNavigate } from 'react-router-dom';
@@ -9,9 +8,7 @@ import useGameContext from 'hooks/useGameContext';
 const App = () => {
   const navigate = useNavigate();
   const location = useLocation();
-  // const { height, width, isPortrait, isLandscape } =
-  //   useContext(BreakpointContext);
-  // console.log(height, width, isPortrait, isLandscape);
+
   const {
     state: { stage },
   } = useGameContext();

--- a/packages/frontend/src/App.jsx
+++ b/packages/frontend/src/App.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react';
+// import { BreakpointContext } from 'contexts/breakpoint';
 import { useLocation } from 'react-router-dom';
 import './styles/App.scss';
 import { Routes, Route, useNavigate } from 'react-router-dom';
@@ -8,7 +9,9 @@ import useGameContext from 'hooks/useGameContext';
 const App = () => {
   const navigate = useNavigate();
   const location = useLocation();
-
+  // const { height, width, isPortrait, isLandscape } =
+  //   useContext(BreakpointContext);
+  // console.log(height, width, isPortrait, isLandscape);
   const {
     state: { stage },
   } = useGameContext();

--- a/packages/frontend/src/components/Game/GameBoard/TileGrid/index.jsx
+++ b/packages/frontend/src/components/Game/GameBoard/TileGrid/index.jsx
@@ -1,13 +1,16 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useContext } from 'react';
 import PropTypes from 'prop-types';
 import Tile from '../Tile';
 import { flipTile, handleFlippedPair } from 'contexts/game/actions';
 import useGameContext from 'hooks/useGameContext';
+import { BreakpointContext } from 'contexts/breakpoint';
 
 const TileGrid = ({ tiles }) => {
   const { state, dispatch } = useGameContext();
 
-  const onFlipTile = (tile) => {
+  const { isPortrait } = useContext(BreakpointContext);
+
+  const onFlipTile = tile => {
     dispatch(flipTile(tile));
   };
 
@@ -20,7 +23,10 @@ const TileGrid = ({ tiles }) => {
   }, [state.flipped, dispatch]);
 
   return (
-    <div data-testid="tile-grid" className="container mt-5">
+    <div
+      data-testid="tile-grid"
+      className={`container${isPortrait ? '-fluid' : ''} bg-dark mt-5`}
+    >
       <div className="row">
         <div className="col-12 col-lg-10 col-md-12 offset-md-0 offset-lg-1">
           <div className="d-flex justify-content-center flex-wrap gap-3">

--- a/packages/frontend/src/components/providers/breakpoint/index.jsx
+++ b/packages/frontend/src/components/providers/breakpoint/index.jsx
@@ -1,0 +1,50 @@
+import React, { useEffect, useState, useMemo } from 'react';
+import { BreakpointContext } from 'contexts/breakpoint';
+import { BREAKPOINTS } from 'utils/breakpoints';
+import { useWindowSize } from '@uidotdev/usehooks';
+import PropTypes from 'prop-types';
+
+const BreakpointProvider = ({ children }) => {
+  const { sm, md, lg, xl, xxl } = BREAKPOINTS;
+  const [breakpoint, setBreakpoint] = useState('sm');
+  const size = useWindowSize();
+
+  const { width, height } = size;
+
+  useEffect(() => {
+    let breakpoint = '';
+
+    if (width < sm) {
+      breakpoint = 'xs';
+    } else if (width < md) {
+      breakpoint = 'sm';
+    } else if (width < lg) {
+      breakpoint = 'md';
+    } else if (width < xl) {
+      breakpoint = 'lg';
+    } else if (width < xxl) {
+      breakpoint = 'xl';
+    } else {
+      breakpoint = 'xxl';
+    }
+    setBreakpoint(breakpoint);
+  }, [size, sm, md, lg, xl, xxl, width]);
+
+  const isLandscape = useMemo(() => width >= height, [width, height]);
+
+  const isPortrait = useMemo(() => width < height, [width, height]);
+
+  return (
+    <BreakpointContext.Provider
+      value={{ width, height, isLandscape, isPortrait, breakpoint }}
+    >
+      {children}
+    </BreakpointContext.Provider>
+  );
+};
+
+BreakpointProvider.propTypes = {
+  children: PropTypes.node,
+};
+
+export default BreakpointProvider;

--- a/packages/frontend/src/contexts/breakpoint/index.js
+++ b/packages/frontend/src/contexts/breakpoint/index.js
@@ -1,0 +1,10 @@
+import { createContext } from 'react';
+
+export const initialBreakpointState = {
+  breakpoint: 'sm',
+  isMobile: true,
+  isPortrait: true,
+  isLandscape: false,
+};
+
+export const BreakpointContext = createContext(initialBreakpointState);

--- a/packages/frontend/src/index.js
+++ b/packages/frontend/src/index.js
@@ -8,6 +8,7 @@ import reportWebVitals from './reportWebVitals';
 import FormProvider from 'components/providers/form';
 import GameProvider from 'components/providers/game';
 import PhotosProvider from 'components/providers/photos';
+import BreakpointProvider from 'components/providers/breakpoint';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
@@ -16,7 +17,9 @@ root.render(
       <FormProvider>
         <PhotosProvider>
           <GameProvider>
-            <App />
+            <BreakpointProvider>
+              <App />
+            </BreakpointProvider>
           </GameProvider>
         </PhotosProvider>
       </FormProvider>

--- a/packages/frontend/src/utils/breakpoints.js
+++ b/packages/frontend/src/utils/breakpoints.js
@@ -1,0 +1,9 @@
+const BREAKPOINTS = Object.freeze({
+  sm: 576,
+  md: 768,
+  lg: 922,
+  xl: 1200,
+  xxl: 1400,
+});
+
+export { BREAKPOINTS };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2797,6 +2797,11 @@
     "@typescript-eslint/types" "5.62.0"
     eslint-visitor-keys "^3.3.0"
 
+"@uidotdev/usehooks@^2.4.1":
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/@uidotdev/usehooks/-/usehooks-2.4.1.tgz#4b733eaeae09a7be143c6c9ca158b56cc1ea75bf"
+  integrity sha512-1I+RwWyS+kdv3Mv0Vmc+p0dPYH0DTRAo04HLyXReYBL9AeseDWUJyi4THuksBJcu9F0Pih69Ak150VDnqbVnXg==
+
 "@webassemblyjs/ast@1.11.6", "@webassemblyjs/ast@^1.11.5":
   version "1.11.6"
   resolved "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.6.tgz"


### PR DESCRIPTION
﻿## Description of changes 

I set up a useBreakpoint context similar to the examples sited, and made some small adjustments to the app level container and tileGrid container, adding a fluid property while in portrait size so that the background color remains the same even when the tileGrid component  extends beyond the height of the screen.

## Test steps

Open dev tools, check that when you start a game with the max amount of sizes, that it looks good in every size, and that the background color remains consistent even on the sizes where you have to scroll down to see the last tile. 
